### PR TITLE
rm place from latimes_place_totals facets.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -96,7 +96,6 @@
                     "sort_desc": "date",
                     "description_html": "<div style='border: 2px solid red; padding: 1em'>⚠️ Consult <a href='https://github.com/simonw/covid-19-datasette/blob/main/README.md'>the README</a> for warnings about using and building on this data. Also review <a href='https://fivethirtyeight.com/features/why-its-so-freaking-hard-to-make-a-good-covid-19-model/'>Why It’s So Freaking Hard To Make A Good COVID-19 Model</a> and <a href='https://medium.com/nightingale/ten-considerations-before-you-create-another-chart-about-covid-19-27d3bd691be8'>Ten Considerations Before You Create Another Chart About COVID-19</a>.</div>",
                     "facets": [
-                        "place",
                         "county",
                         "fips"
                     ],


### PR DESCRIPTION
Closes #24. I tried this change locally on a recent copy of `covid.db` like so:

```
$ wget https://covid-19.datasettes.com/covid.db

$ datasette --metadata metadata.json covid.db 
```

I then avigated to http://localhost:8001/covid/latimes_place_totals and saw error.

```
$ vi metadata.json # applied changes

$ datasette --metadata metadata.json covid.db 
```

 navigated to http://localhost:8001/covid/latimes_place_totals , worked as expected

